### PR TITLE
Revert "fix #9 Generate factory method that takes locale as argument"

### DIFF
--- a/src/main/java/org/gwtproject/tools/cldr/CurrencyListProcessor.java
+++ b/src/main/java/org/gwtproject/tools/cldr/CurrencyListProcessor.java
@@ -140,19 +140,13 @@ public class CurrencyListProcessor extends Processor {
     }
 
     private void generateFactory(String path, String packageName, List<GwtLocale> sorted) throws IOException {
-        MethodSpec.Builder createDefaultMethod = MethodSpec.methodBuilder("create")
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addStatement("return create(System.getProperty($S))", "locale")
-                .returns(CurrencyList.class);
-
         MethodSpec.Builder createMethod = MethodSpec.methodBuilder("create")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter(ParameterSpec.builder(String.class, "locale").build())
                 .returns(CurrencyList.class);
 
         createMethod
                 .addCode(CodeBlock.builder()
-                        .beginControlFlow("if($L.equals($S))", "locale", "default")
+                        .beginControlFlow("if(System.getProperty($S).equals($S))", "locale", "default")
                         .addStatement("return new $T()", ClassName.bestGuess("CurrencyList_"))
                         .endControlFlow()
                         .build());
@@ -162,7 +156,7 @@ public class CurrencyListProcessor extends Processor {
                 if (!gwtLocale.isDefault()) {
                     createMethod
                             .addCode(CodeBlock.builder()
-                                    .beginControlFlow("if($L.startsWith($S))", "locale", gwtLocale.getAsString())
+                                    .beginControlFlow("if(System.getProperty($S).startsWith($S))", "locale", gwtLocale.getAsString())
                                     .addStatement("return new $T()", ClassName.bestGuess("CurrencyList" + Processor.localeSuffix(gwtLocale, "_")))
                                     .endControlFlow()
                                     .build()
@@ -176,7 +170,6 @@ public class CurrencyListProcessor extends Processor {
         TypeSpec.Builder currencyListFactory = TypeSpec.classBuilder("CurrencyList_factory")
                 .addAnnotation(generatedAnnotation(this.getClass()))
                 .addModifiers(Modifier.PUBLIC)
-                .addMethod(createDefaultMethod.build())
                 .addMethod(createMethod.build());
 
         PrintWriter pw = createOutputFile(path + "CurrencyList_factory.java");

--- a/src/main/java/org/gwtproject/tools/cldr/DateTimeFormatInfoProcessor.java
+++ b/src/main/java/org/gwtproject/tools/cldr/DateTimeFormatInfoProcessor.java
@@ -525,11 +525,8 @@ public class DateTimeFormatInfoProcessor extends Processor {
 
         factoryWriter.println("public class DateTimeFormatInfo_factory {");
         factoryWriter.println(" public static DateTimeFormatInfo create(){");
-        factoryWriter.println(" \treturn create(System.getProperty(\"locale\"));");
-        factoryWriter.println(" }");
         factoryWriter.println();
-        factoryWriter.println(" public static DateTimeFormatInfo create(String locale){");
-        factoryWriter.println();
+
         List<GwtLocale> sorted = localesToPrint.stream()
                 .sorted(Comparator.comparing(GwtLocale::getAsString)
                         .reversed())
@@ -548,9 +545,9 @@ public class DateTimeFormatInfoProcessor extends Processor {
 
             String localeName = locale.isDefault() ? "default" : locale.getAsString();
             if(nonNull(locale.getRegion())) {
-                factoryWriter.println("   if(locale.startsWith(\"" + localeName + "\")){");
+                factoryWriter.println("   if(System.getProperty(\"locale\").startsWith(\"" + localeName + "\")){");
             }else{
-                factoryWriter.println("   if(locale.startsWith(\"" + localeName + "_\") || locale.equals(\"" + localeName + "\")){");
+                factoryWriter.println("   if(System.getProperty(\"locale\").startsWith(\"" + localeName + "_\") || System.getProperty(\"locale\").equals(\"" + localeName + "\")){");
             }
             factoryWriter.println("     return new " + className + "();");
             factoryWriter.println("   }");

--- a/src/main/java/org/gwtproject/tools/cldr/ListFormattingProcessor.java
+++ b/src/main/java/org/gwtproject/tools/cldr/ListFormattingProcessor.java
@@ -69,19 +69,13 @@ public class ListFormattingProcessor extends Processor {
     }
 
     private void generateFactory(String path, String packageName, List<GwtLocale> sorted) throws IOException {
-        MethodSpec.Builder createDefaultMethod = MethodSpec.methodBuilder("create")
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addStatement("return create(System.getProperty($S))", "locale")
-                .returns(ListPattern.class);
-
         MethodSpec.Builder createMethod = MethodSpec.methodBuilder("create")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter(ParameterSpec.builder(String.class, "locale").build())
                 .returns(ListPattern.class);
 
         createMethod
                 .addCode(CodeBlock.builder()
-                        .beginControlFlow("if($L.equals($S))", "locale", "default")
+                        .beginControlFlow("if(System.getProperty($S).equals($S))", "locale", "default")
                         .addStatement("return new $T()", ClassName.bestGuess("ListPatternsImpl"))
                         .endControlFlow()
                         .build());
@@ -91,7 +85,7 @@ public class ListFormattingProcessor extends Processor {
                 gwtLocale.isDefault();
                 createMethod
                         .addCode(CodeBlock.builder()
-                                .beginControlFlow("if($L.startsWith($S))", "locale", gwtLocale.getAsString())
+                                .beginControlFlow("if(System.getProperty($S).startsWith($S))", "locale", gwtLocale.getAsString())
                                 .addStatement("return new $T()", ClassName.bestGuess("ListPatternsImpl" + Processor.localeSuffix(gwtLocale, "_")))
                                 .endControlFlow()
                                 .build()
@@ -104,7 +98,6 @@ public class ListFormattingProcessor extends Processor {
         TypeSpec.Builder listPatternsFactory = TypeSpec.classBuilder("ListPatterns_factory")
                 .addAnnotation(generatedAnnotation(this.getClass()))
                 .addModifiers(Modifier.PUBLIC)
-                .addMethod(createDefaultMethod.build())
                 .addMethod(createMethod.build());
 
 

--- a/src/main/java/org/gwtproject/tools/cldr/LocalizedNamesProcessor.java
+++ b/src/main/java/org/gwtproject/tools/cldr/LocalizedNamesProcessor.java
@@ -165,10 +165,6 @@ public class LocalizedNamesProcessor extends Processor {
         factoryWriter.println("public class LocalizedNames_factory {");
         factoryWriter.println();
         factoryWriter.println(" public static LocalizedNames create(){");
-        factoryWriter.println(" \treturn create(System.getProperty(\"locale\"));");
-        factoryWriter.println(" }");
-        factoryWriter.println();
-        factoryWriter.println(" public static LocalizedNames create(String locale){");
         factoryWriter.println();
 
         for (GwtLocale locale : localesToPrint) {
@@ -203,7 +199,7 @@ public class LocalizedNamesProcessor extends Processor {
             }
             String path = cldrDir + "LocalizedNamesImpl" + localePart + "." + "java";
 
-            factoryWriter.println("   if(\"" + locale.getAsString() + "\".equals(locale)){");
+            factoryWriter.println("   if(\"" + locale.getAsString() + "\".equals(System.getProperty(\"locale\"))){");
             factoryWriter.println("     return new LocalizedNamesImpl" + localePart + "();");
             factoryWriter.println("   }");
             factoryWriter.println();

--- a/src/main/java/org/gwtproject/tools/cldr/NumberConstantsProcessor.java
+++ b/src/main/java/org/gwtproject/tools/cldr/NumberConstantsProcessor.java
@@ -118,19 +118,13 @@ public class NumberConstantsProcessor extends Processor {
 
     private void generateFactory(String path, String packageName, List<GwtLocale> sorted) throws IOException {
 
-        MethodSpec.Builder createDefaultMethod = MethodSpec.methodBuilder("create")
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addStatement("return create(System.getProperty($S))", "locale")
-                .returns(NumberConstants.class);
-
         MethodSpec.Builder createMethod = MethodSpec.methodBuilder("create")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter(ParameterSpec.builder(String.class, "locale").build())
                 .returns(NumberConstants.class);
 
         createMethod
                 .addCode(CodeBlock.builder()
-                        .beginControlFlow("if($L.equals($S))", "locale", "default")
+                        .beginControlFlow("if(System.getProperty($S).equals($S))", "locale", "default")
                         .addStatement("return new $T()", ClassName.bestGuess("NumberConstantsImpl"))
                         .endControlFlow()
                         .build());
@@ -140,7 +134,7 @@ public class NumberConstantsProcessor extends Processor {
                 gwtLocale.isDefault();
                 createMethod
                         .addCode(CodeBlock.builder()
-                                .beginControlFlow("if($L.startsWith($S))", "locale", gwtLocale.getAsString())
+                                .beginControlFlow("if(System.getProperty($S).startsWith($S))", "locale", gwtLocale.getAsString())
                                 .addStatement("return new $T()", ClassName.bestGuess("NumberConstantsImpl" + Processor.localeSuffix(gwtLocale)))
                                 .endControlFlow()
                                 .build()
@@ -153,7 +147,6 @@ public class NumberConstantsProcessor extends Processor {
         TypeSpec.Builder numberConstantsFactory = TypeSpec.classBuilder("NumberConstants_factory")
                 .addAnnotation(generatedAnnotation(this.getClass()))
                 .addModifiers(Modifier.PUBLIC)
-                .addMethod(createDefaultMethod.build())
                 .addMethod(createMethod.build());
 
         PrintWriter pw = createOutputFile(path + "NumberConstants_factory.java");


### PR DESCRIPTION
Reverts vegegoku/gwt-cldr-importer#10

The change from the PR made the compilation size of the applications explode, as it prevents the GWT compiler from optimizing the CLDR classes and they all end up in the compiled js.